### PR TITLE
Chore: changes table field name from values to rows

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,7 +54,7 @@ for (var i = 0;i < annotations.length; i++) {
 var table =
   {
     columns: [{text: 'Time', type: 'time'}, {text: 'Country', type: 'string'}, {text: 'Number', type: 'number'}],
-    values: [
+    rows: [
       [ 1234567, 'SE', 123 ],
       [ 1234567, 'DE', 231 ],
       [ 1234567, 'US', 321 ],
@@ -70,8 +70,8 @@ function setCORSHeaders(res) {
 
 var now = Date.now();
 var decreaser = 0;
-for (var i = 0;i < table.values.length; i++) {
-  var anon = table.values[i];
+for (var i = 0;i < table.rows.length; i++) {
+  var anon = table.rows[i];
 
   anon[0] = (now - decreaser);
   decreaser += 1000000


### PR DESCRIPTION
Changes the name of one of table fields storing row values from `values` to `rows` to fix compatibility with current version of Grafana (7.0b1, but should also work with 6.x).
Without that, Grafana throws the following error while pre-processing table data to DataFrames while using simpleJson datasource with `fake-simple-json-datasource`:

```
hostReportError.js:3 Uncaught Error: Expected table rows to be array, got undefined.
    at convertTableToDataFrame (processDataFrame.ts:36)
    at toDataFrame (processDataFrame.ts:294)
    at getProcessedDataFrames (runRequest.ts:193)
    at preProcessPanelData (runRequest.ts:220)
    at MapSubscriber.project (actions.ts:483)
    at MapSubscriber.push../node_modules/rxjs/_esm5/internal/operators/map.js.MapSubscriber._next (map.js:35)
    at MapSubscriber.push../node_modules/rxjs/_esm5/internal/Subscriber.js.Subscriber.next (Subscriber.js:53)
    at MergeMapSubscriber.push../node_modules/rxjs/_esm5/internal/operators/mergeMap.js.MergeMapSubscriber.notifyNext (mergeMap.js:87)
    at InnerSubscriber.push../node_modules/rxjs/_esm5/internal/InnerSubscriber.js.InnerSubscriber._next (InnerSubscriber.js:15)
    at InnerSubscriber.push../node_modules/rxjs/_esm5/internal/Subscriber.js.Subscriber.next (Subscriber.js:53)
```